### PR TITLE
alterado para a imagem de fundo ajustar a tela

### DIFF
--- a/teste/assets/style.css
+++ b/teste/assets/style.css
@@ -388,6 +388,7 @@ header .mobileToggle {
 
 #hero {
 	background: #310404 url(https://i.ytimg.com/vi/wOvQAhzWCrM/maxresdefault.jpg) no-repeat center center fixed;	
+	background-size: cover;
 	padding: 90px 0 200px 0;
 	text-align: center;
 	


### PR DESCRIPTION
A imagem de fundo não está ajustando na tela
![image](https://user-images.githubusercontent.com/4308648/98387233-89a46d80-2027-11eb-8abd-c3f557abe6c8.png)

Nesse PR sugiro o uso do `background-size: cover`, https://developer.mozilla.org/pt-BR/docs/Web/CSS/background-size

Após aplicar esse PR, ela se ajustará
![image](https://user-images.githubusercontent.com/4308648/98387194-7d201500-2027-11eb-976c-033d1a73b30d.png)
